### PR TITLE
refactor: Update Rolling Status Card Content

### DIFF
--- a/views/app/profile/status-report/utils.ts
+++ b/views/app/profile/status-report/utils.ts
@@ -22,9 +22,9 @@ export const getStatusContent = (status: IUserStatus | 'UNKNOWN') => {
         case 'ACTIVE':
             return {
                 subtitle: 'Good standing.',
-                message: "You're maintaining a consistent attendance. Keep it up!",
+                message: "You're doing great! We really appreciate your consistency and heart for service.",
                 streakTitle: 'Active Streak',
-                streakSubtitle: 'Keep the momentum going!',
+                streakSubtitle: "You're on fire! Keep shining.",
                 emoji: '🔥',
                 iconBgColor: 'bg-green-700',
                 bannerBorderColor: 'border-green-200',
@@ -32,38 +32,38 @@ export const getStatusContent = (status: IUserStatus | 'UNKNOWN') => {
                 iconColor: 'green',
                 gradientColors: ['#10b981', '#14b8a6'], // green-500 to teal-500
             };
-        case 'DORMANT':
-            return {
-                subtitle: 'Needs attention.',
-                message: "You've been inactive recently. We'd love to see you back!",
-                streakTitle: 'Dormant Period',
-                streakSubtitle: 'Time to get back on track!',
-                emoji: '😞',
-                iconBgColor: 'bg-amber-600',
-                bannerBorderColor: 'border-amber-200',
-                bannerBgColor: 'bg-amber-50',
-                iconColor: '#d97706', // amber-600
-                gradientColors: ['#f59e0b', '#f97316'], // amber-500 to orange-500
-            };
         case 'INACTIVE':
             return {
                 subtitle: 'Currently inactive.',
-                message: 'Your account is inactive. Please contact your administrator for assistance.',
+                message: "We've missed you! Attending service more often will help you stay active.",
                 streakTitle: 'Inactive Status',
-                streakSubtitle: 'Reach out to get reactivated.',
-                emoji: '💤',
-                iconBgColor: 'bg-gray-600',
-                bannerBorderColor: 'border-gray-200',
-                bannerBgColor: 'bg-gray-50',
-                iconColor: '#6b7280', // gray-500
-                gradientColors: ['#6b7280', '#9ca3af'], // gray-500 to gray-400
+                streakSubtitle: 'Join us for the next service to get back on track!',
+                emoji: '😟',
+                iconBgColor: 'bg-amber-400',
+                bannerBorderColor: 'border-amber-200',
+                bannerBgColor: 'bg-amber-50',
+                iconColor: '#fbbf24', // amber-400
+                gradientColors: ['#fbbf24', '#f59e0b'], // amber-400 to amber-500
+            };
+        case 'DORMANT':
+            return {
+                subtitle: 'Needs attention.',
+                message: "It's been a while! We'd love to have you back—your spot is still waiting.",
+                streakTitle: 'Dormant Period',
+                streakSubtitle: "We've missed you! Ready to start fresh?",
+                emoji: '☹️',
+                iconBgColor: 'bg-amber-600',
+                bannerBorderColor: 'border-amber-300',
+                bannerBgColor: 'bg-amber-100',
+                iconColor: '#d97706', // amber-600
+                gradientColors: ['#f59e0b', '#d97706'], // amber-500 to amber-600
             };
         case 'BLACKLISTED':
             return {
                 subtitle: 'Access restricted.',
-                message: 'Your account has been restricted. Please contact your Pastor/Campus Coordinator.',
+                message: 'Please see your Coordinator or Pastor to get this sorted and resume service.',
                 streakTitle: 'Restricted Access',
-                streakSubtitle: 'Contact your Pastor/Campus Coordinator.',
+                streakSubtitle: 'See your Coordinator to get back on track.',
                 emoji: '😩',
                 iconBgColor: 'bg-red-700',
                 bannerBorderColor: 'border-red-200',
@@ -96,12 +96,12 @@ export const getRollingStatus = (metrics: IGetUserStatusMetric | undefined) => {
         return 'ACTIVE';
     }
 
-    if (metrics?.dormantStreak > 0) {
-        return 'DORMANT';
-    }
-
     if (metrics?.inactiveStreak > 0) {
         return 'INACTIVE';
+    }
+
+    if (metrics?.dormantStreak > 0) {
+        return 'DORMANT';
     }
 
     if (metrics?.blacklistedStreak > 0) {
@@ -120,12 +120,12 @@ export const getCurrentStreak = (metrics: IGetUserStatusMetric | undefined) => {
         return metrics?.activeStreak;
     }
 
-    if (metrics?.dormantStreak > 0) {
-        return metrics?.dormantStreak;
-    }
-
     if (metrics?.inactiveStreak > 0) {
         return metrics?.inactiveStreak;
+    }
+
+    if (metrics?.dormantStreak > 0) {
+        return metrics?.dormantStreak;
     }
 
     if (metrics?.blacklistedStreak > 0) {


### PR DESCRIPTION
# What's Changed

- **Improved Status Messaging**: Shortened and humanized the messages for all workforce statuses (Active, Inactive, Dormant, Blacklisted) to be more engaging and less robotic.
- **Status Progression Update**: Reordered the status hierarchy to follow `Active -> Inactive -> Dormant -> Blacklisted`, ensuring a more logical progression based on attendance patterns.
- **Visual Enhancements**: Updated the **Inactive** and **Dormant** states to use distinct Amber color palettes. Inactive now uses a lighter amber while Dormant uses a darker amber for better visual contrast.
- **Emoji & Tone Updates**: Updated status emojis and refined the tone to be more personal and encouraging for members to return to service.
- **Contextual Messaging**: Removed "reach out to coordinator" instructions from non-restricted statuses, focusing instead on encouraging attendance.

<img width="415" height="302" alt="image" src="https://github.com/user-attachments/assets/7bc435ae-c5e0-4c9e-b125-0e5d917b0b5a" />
<img width="408" height="325" alt="image" src="https://github.com/user-attachments/assets/fcb32337-5f4d-4615-bf2a-7e3d0567a746" />
<img width="412" height="325" alt="image" src="https://github.com/user-attachments/assets/40132c8a-5233-4d4a-99f5-37c0b808b005" />
![Uploading image.png…]()


# Code Changes

- **[utils.ts]**:
  - Reordered [getStatusContent] switch cases and updated color, banner, and text constants for all statuses.
  - Updated [getRollingStatus] and [getCurrentStreak] logic to follow the new `Inactive -> Dormant` precedence.
  - Simplified and shortened message strings across the board for a better fit within the mobile UI.
